### PR TITLE
feat: add additional configuration values for PXC

### DIFF
--- a/roles/xtradb_docker_deploy/defaults/main.yml
+++ b/roles/xtradb_docker_deploy/defaults/main.yml
@@ -39,7 +39,7 @@ xtradb_mysql_docker_volume_path: /data/{{ xtradb_docker_container_name }}/
 xtradb_certs_folder: "{{ xtradb_docker_deploy_base_folder }}/certs"
 xtradb_docker_certs_folder: /cert
 
-xtradb_docker_deploy_files: 
+xtradb_docker_deploy_files:
 - src: "{{ xtradb_certs_ca_key }}"
   dest: "{{ xtradb_certs_folder }}/ca-key.pem"
   service: xtradb
@@ -100,3 +100,6 @@ xtradb_docker_environment_variables_default:
 # CLUSTER_JOIN is not present when deploying the 1st node at 1st time
 xtradb_docker_environment_variables_default_join:
   CLUSTER_JOIN: "{{ xtradb_cluster_hosts | join(',') }}"
+
+xtradb_docker_max_connections: 500
+xtradb_docker_innodb_buffer_pool_size: 5934M

--- a/roles/xtradb_docker_deploy/templates/custom.cnf
+++ b/roles/xtradb_docker_deploy/templates/custom.cnf
@@ -2,6 +2,14 @@
 ssl-ca = /cert/ca.pem
 ssl-cert = /cert/server-cert.pem
 ssl-key = /cert/server-key.pem
+default_authentication_plugin = caching_sha2_password
+log-bin = bin.log
+log-bin-index = bin-log.index
+collation_server = utf8mb4_unicode_ci
+expire_logs_days = 30
+max_binlog_size = 100M
+max_connections = {{ xtradb_docker_max_connections }}
+innodb_buffer_pool_size = {{ xtradb_docker_innodb_buffer_pool_size }}
 
 [client]
 ssl-ca = /cert/ca.pem
@@ -13,3 +21,5 @@ encrypt = 4
 ssl-ca = /cert/ca.pem
 ssl-cert = /cert/server-cert.pem
 ssl-key = /cert/server-key.pem
+
+


### PR DESCRIPTION
The default mysql_native_password plugin is going to be removed in MySQL 8.4. We are migrating all the users to the recommended caching_sha2_password plugin. 