### PR TITLE
Add user and password placeholders in XML config

### DIFF
--- a/roles/clickhouse_docker_deploy/templates/config/20-remote-servers.xml
+++ b/roles/clickhouse_docker_deploy/templates/config/20-remote-servers.xml
@@ -9,6 +9,8 @@
                     <!--  NOTE: This hosts need to be correctly set  -->
                     <host>{{ hostvars[ch_host]['clickhouse_host'] | default(hostvars[ch_host]['ansible_host']) | default(ch_host) }}</host>
                     <port>{{ hostvars[ch_host]['clickhouse_server_tcp_port'] | default(clickhouse_server_tcp_port_default) }}</port>
+                    <user>{{ need to find the var to the CLICKHOUSE_ADMIN_USER }}</user>
+                    <password>{{ need to find the var to the CLICKHOUSE_ADMIN_PASSWORD }}</password>
                 </replica>
 {% endfor %}
             </shard>


### PR DESCRIPTION
This was the culprit of the alembic migrations not working correctly.

I don't know the location of those vars, but I had to edit manually in the cluster servers.