### PR TITLE
feat: grant access to nau analytics on clickhouse

### DIFF
--- a/roles/clickhouse_docker_deploy/templates/users/user_config.xml
+++ b/roles/clickhouse_docker_deploy/templates/users/user_config.xml
@@ -19,5 +19,19 @@
             <http_max_field_value_size>1048576</http_max_field_value_size>
             <http_max_field_name_size>1048576</http_max_field_name_size>
         </default>
+        <readonly>
+            <readonly>1</readonly>
+        </readonly>
     </profiles>
+
+    <users>
+        <nau_analytics>
+            <password><![CDATA[{{ clickhouse_nau_analytics_password }}]]></password>
+            <profile>readonly</profile>
+            <networks>
+              <ip>::/0</ip>
+            </networks>
+            <quota>default</quota>
+        </nau_analytics>
+    </users>
 </clickhouse>


### PR DESCRIPTION
The nau analytics platform will consume data from
our clickhouse database, so to this commit creates and grants access to a new user: nau-analytics