### PR TITLE
feat: deploy docker compose without shell

### DIFF
--- a/roles/clickhouse_docker_deploy/tasks/main.yml
+++ b/roles/clickhouse_docker_deploy/tasks/main.yml
@@ -18,7 +18,6 @@
     docker_deploy_configs:             "{{ clickhouse_docker_deploy_configs | default([]) }}"
     docker_deploy_secrets:             "{{ clickhouse_docker_deploy_secrets | default([]) }}"
     docker_deploy_services_additional: "{{ clickhouse_docker_deploy_services_additional | default([]) }}"
-    docker_deploy_shell: true
     docker_deploy_healthcheck_retries: "{{ clickhouse_docker_deploy_healthcheck_retries }}"
     docker_deploy_healthcheck_delay:   "{{ clickhouse_docker_deploy_healthcheck_delay }}"
   tags:

--- a/roles/elasticsearch_docker_deploy/tasks/main.yml
+++ b/roles/elasticsearch_docker_deploy/tasks/main.yml
@@ -23,7 +23,6 @@
     docker_deploy_configs:             "{{ elasticsearch_docker_deploy_configs | default([]) }}"
     docker_deploy_secrets:             "{{ elasticsearch_docker_deploy_secrets | default([]) }}"
     docker_deploy_services_additional: "{{ elasticsearch_docker_deploy_services_additional | default([]) }}"
-    docker_deploy_shell: true
     docker_deploy_healthcheck_retries: "{{ elasticsearch_docker_deploy_healthcheck_retries }}"
     docker_deploy_healthcheck_delay:   "{{ elasticsearch_docker_deploy_healthcheck_delay }}"
   tags:

--- a/roles/financial_manager_docker_deploy/tasks/main.yml
+++ b/roles/financial_manager_docker_deploy/tasks/main.yml
@@ -24,7 +24,6 @@
     docker_deploy_configs:             "{{ financial_manager_docker_deploy_configs | default([]) }}"
     docker_deploy_secrets:             "{{ financial_manager_docker_deploy_secrets | default([]) }}"
     docker_deploy_services_additional: "{{ financial_manager_docker_deploy_services_additional | default([]) }}"
-    docker_deploy_shell: true
     docker_deploy_healthcheck_delay :  "{{ financial_manager_docker_deploy_healthcheck_delay }}"
     docker_deploy_healthcheck_retries: "{{ financial_manager_docker_deploy_healthcheck_retries }}"
   tags:

--- a/roles/financial_manager_docker_deploy/templates/docker-compose.yml.j2
+++ b/roles/financial_manager_docker_deploy/templates/docker-compose.yml.j2
@@ -3,7 +3,6 @@
 #
 # Docker compose file for financial_manager.
 #
-version: '3.8'
 
 services:
 

--- a/roles/mongo_docker_deploy/tasks/main.yml
+++ b/roles/mongo_docker_deploy/tasks/main.yml
@@ -21,7 +21,6 @@
     docker_deploy_configs:             "{{ mongo_docker_deploy_configs | default([]) }}"
     docker_deploy_secrets:             "{{ mongo_docker_deploy_secrets | default([]) }}"
     docker_deploy_services_additional: "{{ mongo_docker_deploy_services_additional | default([]) }}"
-    docker_deploy_shell: true
     docker_deploy_healthcheck_retries: "{{ mongo_docker_deploy_healthcheck_retries }}"
     docker_deploy_healthcheck_delay:   "{{ mongo_docker_deploy_healthcheck_delay }}"
   tags:

--- a/roles/mysql_docker_deploy/tasks/main.yml
+++ b/roles/mysql_docker_deploy/tasks/main.yml
@@ -41,7 +41,6 @@
     docker_deploy_configs:             "{{ mysql_docker_deploy_configs | default([]) }}"
     docker_deploy_secrets:             "{{ mysql_docker_deploy_secrets | default([]) }}"
     docker_deploy_services_additional: "{{ mysql_docker_deploy_services_additional | default([]) }}"
-    docker_deploy_shell:               true
     docker_deploy_healthcheck_delay :  "{{ mysql_docker_deploy_healthcheck_delay }}"
     docker_deploy_healthcheck_retries: "{{ mysql_docker_deploy_healthcheck_retries }}"
   tags:

--- a/roles/observability_docker_deploy/tasks/main.yml
+++ b/roles/observability_docker_deploy/tasks/main.yml
@@ -11,7 +11,6 @@
     docker_deploy_configs:             "{{ observability_docker_deploy_configs | default([]) }}"
     docker_deploy_secrets:             "{{ observability_docker_deploy_secrets | default([]) }}"
     docker_deploy_services_additional: "{{ observability_docker_deploy_services_additional | default([]) }}"
-    docker_deploy_shell: true
     docker_deploy_healthcheck_delay :  "{{ observability_docker_deploy_healthcheck_delay }}"
     docker_deploy_healthcheck_retries: "{{ observability_docker_deploy_healthcheck_retries }}"
   when: observability_docker_deploy | default(false)

--- a/roles/openark_orchestrator/tasks/main.yml
+++ b/roles/openark_orchestrator/tasks/main.yml
@@ -6,6 +6,5 @@
   vars:
     docker_deploy_base_folder: "{{ openark_orchestrator_docker_deploy_base_folder }}"
     docker_deploy_compose_template: "{{ openark_orchestrator_docker_deploy_compose_template }}"
-    docker_deploy_templates: "{{ openark_orchestrator_docker_deploy_templates }}"
-    docker_deploy_shell: true # use shell directly to start the docker compose
+    docker_deploy_templates: "{{ openark_orchestrator_docker_deploy_templates }}" # use shell directly to start the docker compose
   tags: openark_orchestrator_docker_deploy

--- a/roles/redis_docker_deploy/tasks/main.yml
+++ b/roles/redis_docker_deploy/tasks/main.yml
@@ -18,7 +18,6 @@
     docker_deploy_configs:             "{{ redis_docker_deploy_configs | default([]) }}"
     docker_deploy_secrets:             "{{ redis_docker_deploy_secrets | default([]) }}"
     docker_deploy_services_additional: "{{ redis_docker_deploy_services_additional | default([]) }}"
-    docker_deploy_shell: true
     docker_deploy_healthcheck_delay :  "{{ redis_docker_deploy_healthcheck_delay }}"
     docker_deploy_healthcheck_retries: "{{ redis_docker_deploy_healthcheck_retries }}"
   tags:

--- a/roles/registry_mirror_deploy/tasks/main.yml
+++ b/roles/registry_mirror_deploy/tasks/main.yml
@@ -6,7 +6,6 @@
     docker_deploy_base_folder:        "{{ registry_mirror_docker_deploy_base_folder }}"
     docker_deploy_compose_template:   "{{ registry_mirror_docker_deploy_compose_template }}"
     docker_deploy_templates:          "{{ registry_mirror_docker_deploy_templates }}"
-    docker_deploy_shell:              true
     docker_deploy_folders_additional: "{{ registry_mirror_docker_deploy_folders_additional }}"
   tags:
     - docker_deploy

--- a/roles/xtradb_docker_deploy/tasks/main.yml
+++ b/roles/xtradb_docker_deploy/tasks/main.yml
@@ -18,7 +18,6 @@
     docker_deploy_configs:             "{{ xtradb_docker_deploy_configs | default([]) }}"
     docker_deploy_secrets:             "{{ xtradb_docker_deploy_secrets | default([]) }}"
     docker_deploy_services_additional: "{{ xtradb_docker_deploy_services_additional | default([]) }}"
-    docker_deploy_shell: true
     docker_deploy_healthcheck_retries: "{{ xtradb_docker_deploy_healthcheck_retries }}"
     docker_deploy_healthcheck_delay:   "{{ xtradb_docker_deploy_healthcheck_delay }}"
   tags:


### PR DESCRIPTION
Run the ansible docker deploy without the `docker_deploy_shell`. Meaning it will use the community docker compose ansible to deploy, meaning it will have better compatibility.

fccn/nau-technical#770